### PR TITLE
Refactor frontend to use Axios + TanStack Query, fix logout flow and API paths

### DIFF
--- a/NewsFeedBackend/NewsFeedBackend.http
+++ b/NewsFeedBackend/NewsFeedBackend.http
@@ -1,6 +1,0 @@
-@NewsFeedBackend_HostAddress = http://localhost:5045
-
-GET {{NewsFeedBackend_HostAddress}}/weatherforecast/
-Accept: application/json
-
-###

--- a/NewsFeedBackend/Program.cs
+++ b/NewsFeedBackend/Program.cs
@@ -20,11 +20,13 @@ var serverVersion = new MySqlServerVersion(new Version(8,0,0));
 builder.Services.AddDbContext<AppDbContext>(opt => opt.UseMySql(cs, serverVersion));
 
 builder.Services.AddHttpClient(); // registers IHttpClientFactory
-builder.Services.AddHttpClient("newsdata", c =>
+builder.Services.AddHttpClient("newsdata", (sp, c) =>
 {
-    c.BaseAddress = new Uri("https://newsdata.io/api/1/");
+    var cfg = sp.GetRequiredService<IConfiguration>().GetSection("NewsData");
+    c.BaseAddress = new Uri(cfg["BaseUrl"]!);
     c.Timeout = TimeSpan.FromSeconds(15);
 });
+
 
 // JWT Auth
 var jwtKey = builder.Configuration["Jwt:Key"]!;

--- a/NewsFeedBackend/appsettings.json
+++ b/NewsFeedBackend/appsettings.json
@@ -1,6 +1,8 @@
 {
-   "NewsData": { "ApiKey": "pub_e667f51cb6e946beae5f3ecf4697add2",
-   "DefaultLanguage": "en",
+   "NewsData": {  
+    "BaseUrl": "https://newsdata.io/api/1/",
+    "ApiKey": "pub_e667f51cb6e946beae5f3ecf4697add2",
+    "DefaultLanguage": "en",
     "DefaultQuery": "",     
     "DefaultCountry": "US",         
     "DefaultCategory": ""

--- a/vite-project/.env
+++ b/vite-project/.env
@@ -1,1 +1,1 @@
-VITE_API_BASE=http://localhost:5000
+VITE_API_BASE=http://localhost:5000/api

--- a/vite-project/package-lock.json
+++ b/vite-project/package-lock.json
@@ -8,6 +8,9 @@
       "name": "vite-project",
       "version": "0.0.0",
       "dependencies": {
+        "@tanstack/react-query": "^5.85.6",
+        "@tanstack/react-query-devtools": "^5.85.6",
+        "axios": "^1.11.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0"
       },
@@ -1347,6 +1350,59 @@
         "win32"
       ]
     },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.85.6",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.85.6.tgz",
+      "integrity": "sha512-hCj0TktzdCv2bCepIdfwqVwUVWb+GSHm1Jnn8w+40lfhQ3m7lCO7ADRUJy+2unxQ/nzjh2ipC6ye69NDW3l73g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/query-devtools": {
+      "version": "5.84.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.84.0.tgz",
+      "integrity": "sha512-fbF3n+z1rqhvd9EoGp5knHkv3p5B2Zml1yNRjh7sNXklngYI5RVIWUrUjZ1RIcEoscarUb0+bOvIs5x9dwzOXQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.85.6",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.85.6.tgz",
+      "integrity": "sha512-VUAag4ERjh+qlmg0wNivQIVCZUrYndqYu3/wPCVZd4r0E+1IqotbeyGTc+ICroL/PqbpSaGZg02zSWYfcvxbdA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.85.6"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-query-devtools": {
+      "version": "5.85.6",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.85.6.tgz",
+      "integrity": "sha512-A6rE39FypFV7eonefk4fxC/vuV/7YJMAcQT94CFAvCpiw65QZX8MOuUpdLBeG1cXajy4Pj8T8sEWHigccntJqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-devtools": "5.84.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "^5.85.6",
+        "react": "^18 || ^19"
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1781,6 +1837,23 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
+      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.4",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1843,6 +1916,19 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/callsites": {
@@ -1913,6 +1999,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -1974,12 +2072,80 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.192",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.192.tgz",
       "integrity": "sha512-rP8Ez0w7UNw/9j5eSXCe10o1g/8B1P5SM90PCCMVkIRQn2R0LEHWz4Eh9RnxkniuDe1W0cTSOB3MLlkTGDcuCg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.25.8",
@@ -2349,6 +2515,42 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2364,6 +2566,15 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -2372,6 +2583,43 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/glob-parent": {
@@ -2400,6 +2648,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graphemer": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
@@ -2415,6 +2675,45 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/ignore": {
@@ -2618,6 +2917,15 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -2640,6 +2948,27 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/minimatch": {
@@ -2836,6 +3165,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/vite-project/package.json
+++ b/vite-project/package.json
@@ -10,6 +10,9 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@tanstack/react-query": "^5.85.6",
+    "@tanstack/react-query-devtools": "^5.85.6",
+    "axios": "^1.11.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },

--- a/vite-project/src/App.tsx
+++ b/vite-project/src/App.tsx
@@ -2,23 +2,29 @@ import { useState } from "react";
 import NewsFeed from "./components/NewsFeed";
 import Login from "./components/Login";
 import Preferences from "./components/Preferences";
-import { getToken, getUser } from "./lib/auth";
+import { getToken, getUser, logout } from "./lib/auth";
 import Header from "./components/Header";
 import "./App.css";
 
 export default function App() {
   const [user, setUser] = useState(getUser());
   const token = getToken();
-  const [reloadKey, setReloadKey] = useState(0);
 
   if (!token) return <Login onLoggedIn={u => setUser(u)} />;
 
-   return (
+    return (
     <>
-      <Header title="My Epic News Feed" />
+      <Header 
+  title="My Epic News Feed" 
+  onLogout={() => { 
+    logout();       // clear token/session
+    setUser(null as any);  // force App to render <Login/>
+  }} 
+/>
       <main style={{ width: "min(1100px, 92vw)", margin: "24px auto" }}>
-        <Preferences onChanged={() => setReloadKey((k) => k + 1)} />
-        <NewsFeed refreshKey={reloadKey} />
+        {/* Preferences will invalidate queries directly */}
+        <Preferences />
+        <NewsFeed />
       </main>
     </>
   );

--- a/vite-project/src/components/Header.tsx
+++ b/vite-project/src/components/Header.tsx
@@ -1,11 +1,14 @@
 import { useState } from "react";
 import s from "./header.module.css";
-import { logout, getUserEmail } from "../lib/auth";
+import { getUserEmail } from "../lib/auth";
 import { sendDigest } from "../lib/email";
 
-type Props = { title?: string };
+type Props = { 
+  title?: string; 
+  onLogout?: () => void;   // new prop 
+};
 
-export default function Header({ title = "My Epic News Feed" }: Props) {
+export default function Header({ title = "My Epic News Feed", onLogout }: Props) {
   const email = getUserEmail() ?? "";
   const [sending, setSending] = useState(false);
   const [msg, setMsg] = useState<string>("");
@@ -25,9 +28,9 @@ export default function Header({ title = "My Epic News Feed" }: Props) {
     }
   }
 
-  function onLogout() {
-    logout();
-    location.reload();
+  function handleLogout() {
+    // no location.reload()
+    onLogout?.();
   }
 
   return (
@@ -41,7 +44,7 @@ export default function Header({ title = "My Epic News Feed" }: Props) {
             <button className={`${s.btn} ${s.primary}`} onClick={onEmailMe} disabled={sending}>
               {sending ? "Sending…" : "Email me"}
             </button>
-            <button className={`${s.btn} ${s.ghost}`} onClick={onLogout}>Log out</button>
+            <button className={`${s.btn} ${s.ghost}`} onClick={handleLogout}>Log out</button>
           </div>
         </div>
       </div>

--- a/vite-project/src/components/Preferences.tsx
+++ b/vite-project/src/components/Preferences.tsx
@@ -1,50 +1,57 @@
-import { useEffect, useState } from "react";
+// Preferences.tsx
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { PrefsApi } from "../lib/prefs";
+import { useState } from "react";
 
-export default function Preferences({ onChanged }: { onChanged?: () => void }) {
-  const [keywords, setKeywords] = useState<string[]>([]);
+export default function Preferences() {
+  const qc = useQueryClient();
   const [value, setValue] = useState("");
-  const [err, setErr] = useState("");
 
-  async function load() {
-    try {
-      setErr("");
-      const ks = await PrefsApi.list();
-      setKeywords(ks);
-    } catch (e) {
-      setErr(e instanceof Error ? e.message : "Failed to load preferences");
-    }
-  }
+  const { data: keywords = [], isLoading, error } = useQuery({
+    queryKey: ['prefs','keywords'],
+    queryFn: () => PrefsApi.list(),
+  });
 
-  useEffect(() => { load(); }, []);
-
-  async function add() {
-    const kw = value.trim();
-    if (!kw) return;
-    try {
-      const ks = await PrefsApi.add(kw);
-      setKeywords(ks);
+  const addMut = useMutation({
+    mutationFn: (kw: string) => PrefsApi.add(kw),
+    onMutate: async (kw) => {
+      await qc.cancelQueries({ queryKey: ['prefs','keywords'] });
+      const prev = qc.getQueryData<string[]>(['prefs','keywords']) || [];
+      qc.setQueryData<string[]>(['prefs','keywords'], [...prev, kw]);
+      return { prev };
+    },
+    onError: (_e, _kw, ctx) => { if (ctx?.prev) qc.setQueryData(['prefs','keywords'], ctx.prev); },
+    onSuccess: () => {
       setValue("");
-      onChanged?.();
-    } catch (e) {
-      setErr(e instanceof Error ? e.message : "Failed to add");
-    }
-  }
+      qc.invalidateQueries({ queryKey: ['news','for-me'] });
+    },
+  });
 
-  async function remove(kw: string) {
-    try {
-      await PrefsApi.remove(kw);
-      setKeywords(k => k.filter(x => x !== kw));
-      onChanged?.();
-    } catch (e) {
-      setErr(e instanceof Error ? e.message : "Failed to remove");
-    }
-  }
+  const removeMut = useMutation({
+    mutationFn: (kw: string) => PrefsApi.remove(kw),
+    onMutate: async (kw) => {
+      await qc.cancelQueries({ queryKey: ['prefs','keywords'] });
+      const prev = qc.getQueryData<string[]>(['prefs','keywords']) || [];
+      qc.setQueryData<string[]>(['prefs','keywords'], prev.filter(x => x !== kw));
+      return { prev };
+    },
+    onError: (_e, _kw, ctx) => { if (ctx?.prev) qc.setQueryData(['prefs','keywords'], ctx.prev); },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['news','for-me'] });
+    },
+  });
+
+  const add = () => {
+    const kw = value.trim();
+    if (kw) addMut.mutate(kw);
+  };
 
   return (
     <section style={{ margin: "16px 0", padding: 12, border: "1px solid #ddd", borderRadius: 8 }}>
       <h3 style={{ margin: 0, marginBottom: 8 }}>My Keywords</h3>
-      {err && <div style={{ background: "#fee", padding: 8, borderRadius: 6, marginBottom: 8 }}>{err}</div>}
+      {error && <div style={{ background: "#fee", padding: 8, borderRadius: 6, marginBottom: 8 }}>
+        {(error as Error).message}
+      </div>}
       <div style={{ display: "flex", gap: 8, marginBottom: 12 }}>
         <input
           placeholder="Add a keyword…"
@@ -53,15 +60,22 @@ export default function Preferences({ onChanged }: { onChanged?: () => void }) {
           onKeyDown={e => e.key === "Enter" && add()}
           style={{ flex: 1, padding: 8 }}
         />
-        <button onClick={add}>Add</button>
+        <button onClick={add} disabled={addMut.isPending}>Add</button>
       </div>
+
       <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
-        {keywords.length === 0 && <span style={{ color: "#666" }}>No keywords yet.</span>}
+        {isLoading && <span>Loading…</span>}
+        {!isLoading && keywords.length === 0 && <span style={{ color: "#666" }}>No keywords yet.</span>}
         {keywords.map(kw => (
           <span key={kw} style={{ display: "inline-flex", alignItems: "center", gap: 6, padding: "6px 10px",
             border: "1px solid #ccc", borderRadius: 20 }}>
             {kw}
-            <button onClick={() => remove(kw)} title="Remove" style={{ color: "black",border: "none", background: "transparent", cursor: "pointer" }}>✕</button>
+            <button
+              onClick={() => removeMut.mutate(kw)}
+              title="Remove"
+              style={{ color: "black", border: "none", background: "transparent", cursor: "pointer" }}
+              disabled={removeMut.isPending}
+            >✕</button>
           </span>
         ))}
       </div>

--- a/vite-project/src/index.css
+++ b/vite-project/src/index.css
@@ -24,8 +24,6 @@ a:hover {
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
   min-width: 320px;
   min-height: 100vh;
 }

--- a/vite-project/src/lib/api.ts
+++ b/vite-project/src/lib/api.ts
@@ -1,0 +1,26 @@
+// src/lib/api.ts
+import axios from 'axios'
+import { getToken, logout } from './auth'
+
+export const api = axios.create({
+  baseURL: '/api',
+})
+
+// attach JWT on each request
+api.interceptors.request.use((config) => {
+  const t = getToken()
+  if (t) config.headers.Authorization = `Bearer ${t}`
+  return config
+})
+
+// optional: central 401 handling (no hard reload)
+api.interceptors.response.use(
+  (res) => res,
+  (err) => {
+    if (err?.response?.status === 401) {
+      logout()
+      // let the UI react to missing token (App will show <Login/>)
+    }
+    return Promise.reject(err)
+  }
+)

--- a/vite-project/src/lib/auth.ts
+++ b/vite-project/src/lib/auth.ts
@@ -14,8 +14,8 @@ async function apiPost<TReq, TRes>(path: string, body: TReq): Promise<TRes> {
 }
 
 export const AuthApi = {
-  login:    (req: LoginRequest)    => apiPost<LoginRequest,    AuthResponse>("/api/auth/login", req),
-  register: (req: RegisterRequest) => apiPost<RegisterRequest, AuthResponse>("/api/auth/register", req),
+  login:    (req: LoginRequest)    => apiPost<LoginRequest,    AuthResponse>("/auth/login", req),
+  register: (req: RegisterRequest) => apiPost<RegisterRequest, AuthResponse>("/auth/register", req),
 };
 
 export function saveSession(data: AuthResponse) {

--- a/vite-project/src/lib/prefs.ts
+++ b/vite-project/src/lib/prefs.ts
@@ -1,21 +1,17 @@
-import { API_BASE, getToken } from "./auth";
-
-async function authed<T>(path: string, init?: RequestInit): Promise<T> {
-  const token = getToken();
-  const res = await fetch(`${API_BASE}${path}`, {
-    headers: {
-      "Content-Type": "application/json",
-      ...(token ? { Authorization: `Bearer ${token}` } : {}),
-    },
-    ...init,
-  });
-  const text = await res.text();
-  if (!res.ok) throw new Error(text || `HTTP ${res.status}`);
-  return text ? (JSON.parse(text) as T) : ({} as T);
-}
+import { api } from './api'
 
 export const PrefsApi = {
-  list:  () => authed<string[]>("/api/preferences"),
-  add:   (keyword: string) => authed<string[]>("/api/preferences", { method: "POST", body: JSON.stringify({ keyword }) }),
-  remove:(keyword: string) => authed<void>      (`/api/preferences/${encodeURIComponent(keyword)}`, { method: "DELETE" }),
-};
+  async list(): Promise<string[]> {
+    const { data } = await api.get('/preferences')
+    return data
+  },
+
+  async add(keyword: string): Promise<string[]> {
+    const { data } = await api.post('/preferences', { keyword })
+    return data
+  },
+
+  async remove(keyword: string): Promise<void> {
+    await api.delete(`/preferences/${encodeURIComponent(keyword)}`)
+  },
+}

--- a/vite-project/src/lib/query.ts
+++ b/vite-project/src/lib/query.ts
@@ -1,0 +1,8 @@
+// src/lib/query.ts
+import { QueryClient } from '@tanstack/react-query';
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: { retry: 1, refetchOnWindowFocus: false, staleTime: 30_000 },
+    mutations: { retry: 0 },
+  },
+});

--- a/vite-project/src/main.tsx
+++ b/vite-project/src/main.tsx
@@ -3,8 +3,25 @@ import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
 
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: 1,
+      refetchOnWindowFocus: false,
+      staleTime: 30_000,
+    },
+    mutations: { retry: 0 },
+  },
+})
+
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <QueryClientProvider client={queryClient}>
+      <App />
+      <ReactQueryDevtools initialIsOpen={false} />
+    </QueryClientProvider>
   </StrictMode>,
 )

--- a/vite-project/vite.config.ts
+++ b/vite-project/vite.config.ts
@@ -1,7 +1,15 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
-// https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    proxy: {
+      '/api': {
+        target: 'http://localhost:5000', // ASP.NET backend port
+        changeOrigin: true,
+        secure: false,
+      },
+    },
+  },
 })


### PR DESCRIPTION
Axios client: added a shared api.ts with JWT interceptor and /api base URL; replaced manual fetch wrappers in PrefsApi, AuthApi, and NewsFeed.

TanStack Query integration: introduced QueryClientProvider; migrated NewsFeed and Preferences to use useQuery/useMutation with cache invalidation instead of manual state/prop drilling.

Auth flow: removed full page reload on logout; app now clears session and re-renders <Login/>.

Styles: fixed global CSS centering bug so header is properly sticky at the top.

Vite config: added Vite dev proxy for /api; updated frontend .env to point to backend (VITE_API_BASE=http://localhost:5001/api); small cleanup in backend Program.cs and config.